### PR TITLE
Reached instruction limit fix plus adding NoDataForStockError

### DIFF
--- a/lib/stock_quote/utility.rb
+++ b/lib/stock_quote/utility.rb
@@ -14,6 +14,13 @@ def Date(arg)
   return arg if arg.is_a?(Date)
   Date.parse(arg) if arg.is_a?(String)
 end
+
+class Date
+  def self.min(first, second)
+    first < second ? first : second
+  end
+end
+
 # => Utility String Methods
 class String
   def underscore

--- a/spec/stock_quote_spec.rb
+++ b/spec/stock_quote_spec.rb
@@ -10,7 +10,7 @@ describe StockQuote::Stock do
 
         use_vcr_cassette 'aapl'
 
-        @fields.each do | field |
+        @fields.each do |field|
           it ".#{field}" do
             @stock = StockQuote::Stock.quote('aapl')
             @stock.should respond_to(field.underscore.to_sym)
@@ -66,16 +66,27 @@ describe StockQuote::Stock do
         @stock = StockQuote::Stock.history('aapl', Date.today - 20)
         @stock.count.should >= 1
       end
+
+      it 'succesfuly queries history by default (no start date given' do
+        @stock = StockQuote::Stock.history('aapl')
+        expect(@stock.count).to be >= 1
+      end
     end
 
     context 'failure' do
       use_vcr_cassette 'asdf_history'
 
       it 'should result in a successful query' do
-        @stock = StockQuote::Stock.history('asdf')
-        @stock.response_code.should be_eql(404)
-        @stock.should respond_to(:no_data_message)
-        @stock.no_data_message.should_not be_nil
+        stock = StockQuote::Stock.history('asdf')
+        expect(stock.response_code).to eq(404)
+        expect(stock).to respond_to(:no_data_message)
+        expect(stock.no_data_message).not_to be_nil
+      end
+
+      it 'should raise ArgumentError if start date is after end date' do
+        expect do
+          StockQuote::Stock.history('aapl', Date.today + 2, Date.today)
+        end.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/utility_spec.rb
+++ b/spec/utility_spec.rb
@@ -16,3 +16,13 @@ describe 'Date() kernel function' do
     end.to raise_error
   end
 end
+
+describe Date do
+  describe '::min' do
+    it 'returns the minimum of two dates passed' do
+      expect(Date.min(Date.parse('2000-01-01'), Date.parse('2012-01-01')))
+        .to eq(Date.parse('2000-01-01'))
+    end
+  end
+end
+

--- a/stock_quote.gemspec
+++ b/stock_quote.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 2.9'
   s.add_development_dependency 'webmock', '~> 1.17'
   s.add_development_dependency 'rubocop', '~> 0.20'
+  s.add_development_dependency 'debugger'
   s.add_runtime_dependency 'rest-client', '~> 1.6'
   s.add_runtime_dependency 'json'
 


### PR DESCRIPTION
- paginates quotes when history requested with dates more than a year apart
- follows the NilObject pattern for returning an error response to maintain backwards compatibility
- uses the diagnostics from the YQL response for printing warnings
- adds deprecation warnings for Stock::success? and Stock::failure? as those should be only called on `NoDataForStockError`
