### PR TITLE
returns 0 for simple return if only one price is returned from request.

### DIFF
--- a/lib/stock_quote/stock.rb
+++ b/lib/stock_quote/stock.rb
@@ -85,12 +85,17 @@ module StockQuote
 
       quotes = []
       begin
-        quotes += quote(
+        year_quotes = quote(
           symbol,
           start,
           min_date(finish, start + 365),
           "Close"
         )
+        if year_quotes.is_a?(Array)
+          quotes += year_quotes
+        else
+          return 0
+        end
         start += 365
       end until finish - start < 365
       quotes

--- a/spec/stock_quote_spec.rb
+++ b/spec/stock_quote_spec.rb
@@ -100,6 +100,15 @@ describe StockQuote::Stock do
         )
         expect(simple_return).to eq(2.205578386790845)
       end
+
+      it 'should return 0 if only one price is found' do
+        simple_return = StockQuote::Stock.simple_return(
+          'TSTA',
+          Date.parse('20130201'),
+          Date.parse('20130501')
+        )
+        expect(simple_return).to eq(0)
+      end
     end
 
     context 'failure' do


### PR DESCRIPTION
if the prices returned when calculating simple returns only has one price it fails out, this does a check and forces a 0% return if only one price is returned
