### PR TITLE
fix/verify_ssl :: yahooapis.com appears to be having some SSL issues. 

### DIFF
--- a/lib/stock_quote/stock.rb
+++ b/lib/stock_quote/stock.rb
@@ -75,8 +75,7 @@ module StockQuote
         url += URI.encode("SELECT #{ select } FROM yahoo.finance.quotes WHERE symbol IN (#{to_p(symbol)})")
       end
       url += '&format=json&diagnostics=true&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys&callback='
-
-      RestClient.get(url) do |response|
+      RestClient::Request.execute(:url => url, :method => :get, :verify_ssl => false) do |response|
         if response.code == 200
           parse(response, symbol, format)
         else

--- a/lib/stock_quote/version.rb
+++ b/lib/stock_quote/version.rb
@@ -1,4 +1,4 @@
 # => StockQuote::VERSION
 module StockQuote
-  VERSION = '1.1.8'
+  VERSION = '1.1.9'
 end


### PR DESCRIPTION
This fix tells RestClient not to verify_ssl, which in turn will hopefully get a valid response, even if the cert is invalid.
