### PR TITLE
Constrain date-matching regex to match full lines

### DIFF
--- a/lib/stock_quote/utility.rb
+++ b/lib/stock_quote/utility.rb
@@ -36,9 +36,9 @@ module StockQuote
     end
 
     def to_date(string)
-      if string.is_a?(String) && string.match(/\d{4}-\d{2}-\d{2}/)
+      if string.is_a?(String) && string.match(/^\d{4}-\d{2}-\d{2}$/)
         Date.strptime(string, '%Y-%m-%d')
-      elsif string.is_a?(String) && string.match(/\d{2}\/\d{2}\/\d{4}/)
+      elsif string.is_a?(String) && string.match(/^\d{2}\/\d{2}\/\d{4}$/)
         Date.strptime(string, '%m/%d/%Y')
       else
         string


### PR DESCRIPTION
Symbol `YCAAO.BA` has some dates in the format `YPF SA FR BDS 21/10/2023 ARS1` that was matching the `/\d{2}\/\d{2}\/\d{4}/` regex for date parsing, but fails because `strptime` errors against the defined template.

This PR adds start-of-line and end-of-line tokens to the string matching so that `strptime` only parses dates that match the defined formats _and no more_. For example, it will continue to match `02-25-1991`, but will not match `ABC 02-25-1991` or `02-25-1991 XYZ`. If a date can't be parsed by `strptime`, parsing falls back on just returning the original string as per existing functionality. 

Fixes #29. :+1: 