### PR TITLE
Deprecate Historical Quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ A ruby gem that retrieves stock quotes and historical pricing from ~~google~~ ya
 
 # Update
 
-On November 1, 2013, Google discontinued iGoogle, which contained the api endpoint stock_quote utilized, rendering the gem inoperable.
-
-As of November 2nd, 2013, the stock_quote gem has been rebuilt to use the Yahoo finance api, starting with version 1.1.0.  All applications leveraging this gem should update to 1.1.0 to resume operation. The gem methods are the same, but responses have been modified to leverage the new api.  Documentation has been updated to reflect these changes.
-
-On November 7th, 2014, some users reported sporadic SSL issues with yahoo preventing the gem from making successful queries. These issues were solved in version 1.2.0 by choosing to not verify yahoo's SSL certificate. If you experience issues with Yahoo's incorrect SSL certificate, with versions 1.1.8 or below, please update the gem.
+On May 17th, 2017, Yahoo discontinued portions of the finance API related to historical quotes.
 
 ## Installation
 
@@ -57,16 +53,6 @@ Each stock object has the following values:
 `symbol, ask, average_daily_volume, bid, ask_realtime, bid_realtime, book_value, change_percent_change, change, commission, change_realtime, after_hours_change_realtime, dividend_share, last_trade_date, trade_date, earnings_share, error_indicationreturnedforsymbolchangedinvalid, eps_estimate_current_year, eps_estimate_next_year, eps_estimate_next_quarter, days_low, days_high, year_low, year_high, holdings_gain_percent, annualized_gain, holdings_gain, holdings_gain_percent_realtime, holdings_gain_realtime, more_info, order_book_realtime, market_capitalization, market_cap_realtime, ebitda, change_from_year_low, percent_change_from_year_low, last_trade_realtime_with_time, change_percent_realtime, change_from_year_high, percent_change_from_year_high, last_trade_with_time, last_trade_price_only, high_limit, low_limit, days_range, days_range_realtime, fiftyday_moving_average, two_hundredday_moving_average, change_from_two_hundredday_moving_average, percent_change_from_two_hundredday_moving_average, change_from_fiftyday_moving_average, percent_change_from_fiftyday_moving_average, name, notes, open, previous_close, price_paid, changein_percent, price_sales, price_book, ex_dividend_date, pe_ratio, dividend_pay_date, pe_ratio_realtime, peg_ratio, price_eps_estimate_current_year, price_eps_estimate_next_year, symbol, shares_owned, short_ratio, last_trade_time, ticker_trend, oneyr_target_price, volume, holdings_value, holdings_value_realtime, year_range, days_value_change, days_value_change_realtime, stock_exchange, dividend_yield, percent_change, error_indicationreturnedforsymbolchangedinvalid, date, open, high, low, close, adj_close`
 
 Additionally, CamelCase method aliases exist for each attribute.
-
-### Date Range
-
-If you pass quote a start_date and end_date it will do a historical query within the date range as opposed to a realtime quote.  Only one stock symbol should be used for historical quotes
-
-Historical queries provide an array of Price objects with the following values:
-
-`Symbol, Date, Open, High, Low, Close, Volume`
-
-A alias is also available:  StockQuote::Stock.history(symbol, start_date, end_date)
 
 ### Symbol Lookup
 

--- a/lib/stock_quote/stock.rb
+++ b/lib/stock_quote/stock.rb
@@ -147,19 +147,7 @@ module StockQuote
     end
 
     def self.history(symbol, start_date = '2012-01-01', end_date = Date.today, select = '*', format = 'instance')
-      start, finish = to_date(start_date), to_date(end_date)
-      raise ArgumentError.new('start dt after end dt') if start > finish
-
-      quotes = []
-      begin
-        quote = quote(symbol, start, min_date(finish, start + 365), select, format)
-        quotes += !!(format=='json') ? quote['quote'] : Array(quote)
-        start += 365
-      end until finish - start < 365
-      return !!(format=='json') ? { 'quote' => quotes } : quotes
-
-    rescue NoDataForStockError => e
-      return e
+      raise(ApiChange, "Yahoo discontinued the historical quote API on May 17th, 2017.")
     end
 
     def self.json_history(symbol, start_date = '2012-01-01', end_date = Date.today, select = '*', format = 'json')

--- a/lib/stock_quote/symbol.rb
+++ b/lib/stock_quote/symbol.rb
@@ -5,6 +5,7 @@ include StockQuote::Utility
 
 module StockQuote
   class NoDataForCompanyError < StandardError; end
+  class ApiChange < StandardError; end
 
   class Symbol
     FIELDS = %w[symbol name exch type exchDisp typeDisp].freeze

--- a/lib/stock_quote/version.rb
+++ b/lib/stock_quote/version.rb
@@ -1,4 +1,4 @@
 # => StockQuote::VERSION
 module StockQuote
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/spec/stock_quote_spec.rb
+++ b/spec/stock_quote_spec.rb
@@ -97,43 +97,11 @@ describe StockQuote::Stock do
     end
   end
 
-  describe 'history' do
-    context 'success', vcr: { cassette_name: 'aapl_history'} do
-
-      it 'should result in a successful query' do
-        @stock = StockQuote::Stock.history('aapl', Date.today - 20)
-        expect(@stock.count).to be >= 1
-      end
-
-      it 'succesfuly queries history by default (no start date given' do
-        @stock = StockQuote::Stock.history('aapl')
-        expect(@stock.count).to be >= 1
-      end
-
-      it 'succesfuly queries history by default (no start date given' do
-        @stock = StockQuote::Stock.history(
-          'aapl',
-          Date.parse('20130103'),
-          Date.parse('20130103')
-        )
-        expect(@stock.count).to be == 1
-      end
-    end
-
-    context 'failure', vcr: { cassette_name: 'asdf_history'} do
-
-      it 'should not result in a successful query' do
-        stock = StockQuote::Stock.history('asdf')
-        expect(stock.response_code).to eq(404)
-        expect(stock).to respond_to(:no_data_message)
-        expect(stock.no_data_message).not_to be_nil
-      end
-
-      it 'should raise ArgumentError if start date is after end date' do
-        expect do
-          s = StockQuote::Stock.history('aapl', Date.today + 2, Date.today)
-        end.to raise_error(ArgumentError)
-      end
+  describe 'history', vcr: { cassette_name: 'aapl_history'} do
+    it 'should raise API Change Error' do
+      expect do
+        s = StockQuote::Stock.history('aapl', Date.today, Date.today+2)
+      end.to raise_error(StockQuote::ApiChange)
     end
   end
 
@@ -172,53 +140,11 @@ describe StockQuote::Stock do
       end
       describe 'history', vcr: { cassette_name: 'aapl_history'} do
 
-        it 'should result in a successful query' do
-          @stock = StockQuote::Stock.json_history('aapl', Date.today - 20)
-          expect(@stock.is_a?(Hash)).to be(true)
-          expect(@stock).to include('quote')
+        it 'should raise API Change Error' do
+          expect do
+            StockQuote::Stock.json_history('aapl', Date.today - 20)
+          end.to raise_error(StockQuote::ApiChange)
         end
-      end
-    end
-  end
-
-  describe 'simple_return' do
-    context 'success', vcr: { cassette_name: 'aapl_simple_return'} do
-
-      it 'should result in a successful query' do
-        simple_return = StockQuote::Stock.simple_return(
-          'aapl',
-          Date.parse('2012-01-03'),
-          Date.parse('2012-01-20')
-        )
-        expect(simple_return).to eq(2.2055800890012827)
-      end
-
-      it 'should return 0 if only one price is found' do
-        simple_return = StockQuote::Stock.simple_return(
-          'TSTA',
-          Date.parse('20130201'),
-          Date.parse('20130501')
-        )
-        expect(simple_return).to eq(0)
-      end
-    end
-
-    context 'failure', vcr: { cassette_name: 'asdf_simple_return'} do
-
-      it 'should not result in a successful query' do
-        expect do
-          stock = StockQuote::Stock.simple_return(
-            'asdf',
-            Date.parse('2012-01-03'),
-            Date.parse('2012-01-20')
-          )
-        end.to raise_error(StockQuote::NoDataForStockError)
-      end
-
-      it 'should raise ArgumentError if start date is after end date' do
-        expect do
-          s = StockQuote::Stock.simple_return('aapl', Date.today + 2, Date.today)
-        end.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/utility_spec.rb
+++ b/spec/utility_spec.rb
@@ -17,7 +17,7 @@ describe 'Date() kernel function' do
   it 'will raise an invalid Date error if it cannot convert arg into date' do
     expect do
       to_date('abcd').to eq(Date.parse('2012-01-01'))
-    end.to raise_error
+    end.to raise_error(NoMethodError)
   end
 end
 


### PR DESCRIPTION
On May 17th, 2017, Yahoo discontinued portions of the finance API related to historical quotes.

This commit raises an ApiChange error on historical quotes alerting users to the fact that the functionality is no longer available.

Version bump to 1.4.0.