### PR TITLE
IEX Trading API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # stock_quote
 
-Real-time, stock data and historical pricing using the Google Finance API.
+Real-time, stock data and historical pricing. Data provided for free by [IEX](https://iextrading.com/developer/).
 
 # Update
 
-On November 1st, 2017, Yahoo Finance terminated public access to the API and stock_quote ceased to function in it's current state.  Therefore, Version 1.5.0 now utilizes the Google Finance API and although functionally similar, the results, and therefore attributes, have changed. Please update accordingly.
+On March 17, 2018, Google Finance terminated public access to it's API.  As a result, Version 2.0.0 of stock_quote now uses the IEX Trading API (iextrading.com). Although functionally similar, the results, and therefore attributes, had changed. Please update accordingly. 
 
 ## Installation
 
@@ -16,11 +16,13 @@ To install the 'stock_quote' ruby gem:
 
 To use the gem in your Rails Application, include it in your Gemfile:
 
-`gem "stock_quote"`
+`gem "stock_quote"`, github: 'tyrauber/stock_quote', branch: 'iex'
 
-## Usage
+### StockQuote::Stock.quote(symbol)
 
-### Quote
+Quote is the primary method, returning a StockQuote::Stock instance, including the following attributes (new in v2.0.0).
+
+`symbol, company_name, primary_exchange, sector, calculation_price, open, open_time, close, close_time, high, low, latest_price, latest_source, latest_time, latest_update, latest_volume, iex_realtime_price, iex_realtime_size, iex_last_updated, delayed_price, delayed_price_time, previous_close, change, change_percent, iex_market_percent, iex_volume, avg_total_volume, iex_bid_price, iex_bid_size, iex_ask_price, iex_ask_size, market_cap, pe_ratio, week52_high, week52_low, ytd_change, chart`
 
 You can get a current quote with the following syntax:
 
@@ -28,42 +30,78 @@ You can get a current quote with the following syntax:
 
 Where symbol equals the company stock symbol you want a quote for. For example, "aapl" for Apple, Inc.
 
-You may search for multiple stocks by separating symbols with a comma. For example:
+You may search for multiple stocks by separating symbols with a comma (or array). For example:
 
 `stocks = StockQuote::Stock.quote("aapl,tsla")`
 
 These queries will return a Stock object or an array of Stock objects which you may iterate through. 
 
-Each stock object has the following values:
+Note: You can receive a raw json hash response with the following syntax:
 
-`symbol, exchange, id, t, e, name, f_reuters_url, f_recent_quarter_date, f_annlyal_date, f_ttm_date, financials, kr_recent_quarter_date, kr_annual_date, kr_ttm_date, c, l, cp, ccol, op, hi, lo, vo, avvo, hi52,  lo52, mc, pe, fwpe, beta, eps, dy, ldiv, shares, instown, eo, sid, sname, iid, iname, related, summary, management, moreresources, events`
+`stocks = StockQuote::Stock.raw_quote("aapl,tsla")`
 
-Among others.
+The raw_ method is available on all supported methods.
 
-### History
+### Other Methods
 
-History is available by providing and start date, or a start date and end date.
+The IEX API is quite extensive and well documented.
 
-`stock = StockQuote::Stock.history("symbol", "start_date", "end_date")`
+V2.0.0 of stock_quote mirrors the IEX API:
 
-The stock instance will contain a symbol and history attribute, containing an array of hashes including date, open, high, low, close and volume.
+* [book](https://iextrading.com/developer/docs/#book)
+* [chart](https://iextrading.com/developer/docs/#chart)
+* [company](https://iextrading.com/developer/docs/#company)
+* [delayed_quote](https://iextrading.com/developer/docs/#delayed-quote)
+* [dividends](https://iextrading.com/developer/docs/#dividends)
+* [earnings](https://iextrading.com/developer/docs/#earnings)
+* [effective_spread](https://iextrading.com/developer/docs/#effective-spread)
+* [financials](https://iextrading.com/developer/docs/#financials)
+* [stats](https://iextrading.com/developer/docs/#key-stats)
+* [logo](https://iextrading.com/developer/docs/#logo)
+* [news](https://iextrading.com/developer/docs/#news)
+* [ohlc](https://iextrading.com/developer/docs/#ohlc)
+* [peers](https://iextrading.com/developer/docs/#peers)
+* [previous](https://iextrading.com/developer/docs/#previous)
+* [price](https://iextrading.com/developer/docs/#price)
+* [quote](https://iextrading.com/developer/docs/#quote)
+* [relevant](https://iextrading.com/developer/docs/#relevant)
+* [splits](https://iextrading.com/developer/docs/#splits)
+* [volume_by_venue](https://iextrading.com/developer/docs/#volume-by-venue)
 
-Date format is impressively flexible. 01-Jan-2016, 01-January-2016, January 01, 2016, 01/01/2016, 01-01-2016, 01-01-16 are all accepted.
+### [batch](https://iextrading.com/developer/docs/#batch-requests)
 
-### Format
+Batch allows you to batch requests.  All methods in stock_quote use batch under-the-hood.
 
-If you prefer raw json as opposed to Stock instances, you may use the following convenience methods:
+Batch follows the syntax:
 
-`stocks = StockQuote::Stock.json_quote('aapl')`
+`StockQuote::Stock.batch(type, symbol, range)`
 
-`stocks = StockQuote::Stock.json_history('aapl')`
+Where type can be multiple of the above methods and symbol can be an array of company symbols.
 
-All other options are also available.
+Range can be:
+
+`5y, 2y, 1y, ytd, 6m, 3m, 1m, 1d, date, dynmaic`
+
+And are applied to chart method.
+
+#### TBD
+
+The following IEX methods are currently unsupported:
+
+* [list](https://iextrading.com/developer/docs/#list)
+  * mostactive
+  * gainers
+  * losers
+  * iexvolume
+  * iexvolume
+* [threshold_securities](https://iextrading.com/developer/docs/#iex-regulation-sho-threshold-securities-list)
+* [short_interest](https://iextrading.com/developer/docs/#iex-short-interest-list)
 
 
 ## Special thanks to
 
-...~~Google~~ ~~Yahoo~~ Google for making this api publicly available.
+IEX for making this api publicly available.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Real-time, stock data and historical pricing. Data provided for free by [IEX](ht
 
 # Update
 
-On March 17, 2018, Google Finance terminated public access to it's API.  As a result, Version 2.0.0 of stock_quote now uses the IEX Trading API (iextrading.com). Although functionally similar, the results, and therefore attributes, had changed. Please update accordingly. 
+On March 17, 2018, Google Finance terminated public access to it's API.  As a result, previous versions of stock_quote ceased to fuuntion. Therefore, Version 2.0.0 of stock_quote now uses the IEX Trading API (iextrading.com). Although some functionalility is similar, the results, and therefore attributes, had changed. Please review the doumentation below and update accordingly. 
 
 ## Installation
 
@@ -16,7 +16,7 @@ To install the 'stock_quote' ruby gem:
 
 To use the gem in your Rails Application, include it in your Gemfile:
 
-`gem "stock_quote"`, github: 'tyrauber/stock_quote', branch: 'iex'
+`gem "stock_quote"`, '~> 2.0.0'
 
 ### StockQuote::Stock.quote(symbol)
 
@@ -68,6 +68,28 @@ V2.0.0 of stock_quote mirrors the IEX API:
 * [splits](https://iextrading.com/developer/docs/#splits)
 * [volume_by_venue](https://iextrading.com/developer/docs/#volume-by-venue)
 
+All these methods are available on StockQuote::Stock.
+
+For example:
+
+```StockQuote::Stock.company('aapl')`
+
+Retrieves company information.
+
+For example:
+
+```StockQuote::Stock.dividends('aapl')`
+
+Retrieves dividend information.
+
+Raw json hash responses are available for any of the methods by pre-fixing the method name with "raw__".
+
+For example:
+
+```StockQuote::Stock.raw_dividends('aapl')`
+
+Retrieves raw dividend information.
+
 ### [batch](https://iextrading.com/developer/docs/#batch-requests)
 
 Batch allows you to batch requests.  All methods in stock_quote use batch under-the-hood.
@@ -105,7 +127,7 @@ IEX for making this api publicly available.
 
 ## License
 
-Copyright (c) 2017 Ty Rauber
+Copyright (c) 2018 Ty Rauber
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Where type can be multiple of the above methods and symbol can be an array of co
 
 Range can be:
 
-`5y, 2y, 1y, ytd, 6m, 3m, 1m, 1d, date, dynmaic`
+`5y, 2y, 1y, ytd, 6m, 3m, 1m, 1d
 
 And are applied to chart method.
 

--- a/lib/stock_quote/stock.rb
+++ b/lib/stock_quote/stock.rb
@@ -37,7 +37,7 @@ module StockQuote
 
     def initialize(data={})
       data.each {|k,v|
-        self.class.__send__(:attr_accessor, k.to_sym)
+        self.class.__send__(:attr_accessor, Util.underscore(k).to_sym)
         self.instance_variable_set("@#{Util.underscore(k)}".to_sym, v)
       }
       @attribution = ATTRIBUTION

--- a/lib/stock_quote/stock.rb
+++ b/lib/stock_quote/stock.rb
@@ -5,72 +5,92 @@ require 'csv'
 
 module StockQuote
 
-  # => SecQuote::Stock
-  # Queries GoogleFinance for current and historical pricing.
+  # => StockQuote::Stock
+  # Queries IEX for current and historical pricing.
 
   class Stock
 
-   FIELDS = %w(symbol exchange id t e name f_reuters_url f_recent_quarter_date f_annlyal_date f_ttm_date financials kr_recent_quarter_date kr_annual_date kr_ttm_date c l cp ccol op hi lo vo avvo hi52 lo52 mc pe fwpe beta eps dy ldiv shares instown eo sid sname iid iname related summary management moreresources events)
-
-   FIELDS.each do |k|
-      __send__(:attr_accessor, k.to_sym)
+    VERSION = "1.0"
+    URL =  "https://api.iextrading.com/#{VERSION}/stock/"
+    ATTRIBUTION = "Data provided for free by IEX (https://iextrading.com/developer)."
+    RANGES = ['5y','2y','1y','ytd','6m','3m','1m','1d']
+    TYPES = ['book', 'chart', 'company', 'delayed_quote', 'dividends', 'earnings', 'effective_spread', 'financials', 'splits', 'stats','logo', 'news', 'ohlc', 'peers', 'previous', 'quote', 'relevant', 'splits',  'volume_by_venue']
+    # LISTS = ['mostactive','gainers', 'losers', 'iexvolume','iexvolume']
+    # TBD = ['threshold_securities','short_interest']
+  
+    class << self
+      def create_method(name)
+        self.class.instance_eval do
+          define_method(name) {|symbol, range=nil| batch(name, symbol, range) }
+          define_method("raw_#{name}") {|symbol, range=nil| batch(name, symbol, range, 'json') }
+        end
+      end
     end
 
-    attr_accessor :response_code, :history
+    attr_accessor :response_code, :attribution
+
+    protected
+
+    TYPES.each do |k|
+      create_method(k)
+    end
 
     def initialize(data={})
       data.each {|k,v|
-        self.instance_variable_set("@#{k}".to_sym, v)
+        self.class.__send__(:attr_accessor, k.to_sym)
+        self.instance_variable_set("@#{Util.underscore(k)}".to_sym, v)
       }
-      @response_code = 200
+      @attribution = ATTRIBUTION
+      @response_code = !!([{}, nil, ''].include?(data)) ? 500 :  200
     end
 
-    def self.quote(symbol, startdate=nil, enddate=nil, format= nil)
-      url = "https://finance.google.com/finance#{!!(startdate || enddate) ? '/historical' : ''}"
-      params = {}
-      results = []
-      params.merge!(output:  !!(startdate || enddate) ? 'csv' : 'json')
-      params.merge!(startdate: startdate) if !!(startdate)
-      params.merge!(enddate: enddate) if !!(enddate)
-      symbol.split(/,/).each do |s|
-        params.merge!(q: s)
-        u = "#{url}?#{URI.encode_www_form(params)}"
-        RestClient::Request.execute(:url => u, :method => :get, :verify_ssl => false) do |response|
-          if !!(startdate || enddate)
-            fail "Invalid Query" if response.body.match(/^<!DOCTYPE html>/)
-            csv = CSV.new(response.body[3..-1], :headers => true, :header_converters => :symbol, :converters => :all)
-            json = {symbol: s, history: csv.to_a.map {|row| row.to_hash }}
-            if format == 'json'
-              results << json
+    def self.batch_url(types, symbols, range)
+      symbols = symbols.is_a?(Array) ? symbols : symbols.split(",")
+      types = types.is_a?(Array) ? types : types.split(",")
+      if !(['dividends', 'splits'] & types).empty?
+        raise "#{types.join(",")} requires a Range: #{RANGES.join(", ")}" unless RANGES.include?(range)
+        range = RANGES.include?(range) ? range : nil
+      end
+      arr = [['symbols', symbols.join(',')], ['types', types.map{|t| t.gsub("_", "-")}.join(',')]]
+      arr.push(['range', range]) if !!(range)
+      return "#{URL}market/batch?#{URI.encode_www_form(arr)}"
+    end
+
+    def self.batch(type, symbol, range=nil,fmt=false)
+      raise "Type and symbol required" unless type && symbol
+      url =  batch_url(type, symbol, range)
+      #p url
+      return request(url, fmt)
+    end
+    
+    def self.request(url, fmt, results=[])
+      RestClient::Request.execute(:url =>  url, :method => :get, :verify_ssl => false) do |response|
+        json = JSON.parse(response)
+        return json if fmt=='json'
+        results = json.map do |symbol, types|
+          result = {}
+          types.map do |type, res|
+            if res.is_a?(Array)
+              result[type.gsub("-", "_")] = res
             else
-              results << Stock.new(json)
+              res.map{|k,v| result[k] = v }
             end
-          else
-            json = response.body.gsub(/\n/, "")
-            json = json.match(/\/\/ \[/) ? JSON.parse(json[3..-1])[0] : JSON.parse(json)["searchresults"]
-            if json.is_a?(Array)
-              json.each do |j|
-                results << (format=='json' ? j : Stock.new(j))
-              end
-            else
-              results << (format=='json' ? json : Stock.new(json))
-            end
+            result['symbol'] ||= symbol
           end
+          Stock.new(result)
         end
       end
       return results.length > 1 ? results : results.shift
     end
+  end
 
-    def self.json_quote(symbol, format='json')
-      self.quote(symbol, nil, nil, format)
-    end
-
-    def self.history(symbol, start_date=nil, end_date=nil, format='json')
-      self.quote(symbol, start_date, end_date, format)
-    end
-
-    def self.json_history(symbol, start_date=nil, end_date=nil, format='json')
-      self.quote(symbol, start_date, end_date, format)
+  class Util
+    def self.underscore(str)
+      str.gsub(/::/, '/').
+      gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+      gsub(/([a-z\d])([A-Z])/,'\1_\2').
+      tr("-", "_").
+      downcase
     end
   end
 end

--- a/lib/stock_quote/version.rb
+++ b/lib/stock_quote/version.rb
@@ -1,4 +1,4 @@
 # => StockQuote::VERSION
 module StockQuote
-  VERSION = '1.6.1'
+  VERSION = '2.0.0'
 end

--- a/lib/stock_quote/version.rb
+++ b/lib/stock_quote/version.rb
@@ -1,4 +1,4 @@
 # => StockQuote::VERSION
 module StockQuote
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end

--- a/lib/stock_quote/version.rb
+++ b/lib/stock_quote/version.rb
@@ -1,4 +1,4 @@
 # => StockQuote::VERSION
 module StockQuote
-  VERSION = '1.5.4'
+  VERSION = '1.6.0'
 end

--- a/spec/stock_quote_spec.rb
+++ b/spec/stock_quote_spec.rb
@@ -2,115 +2,107 @@ require 'stock_quote'
 require 'spec_helper'
 
 describe StockQuote::Stock do
-  describe 'quote' do
-    describe 'single symbol', vcr: { cassette_name: "aapl"} do
-
-      before(:all) do
-        VCR.use_cassette("aapl") do
-          @stock = StockQuote::Stock.quote('aapl')
-        end
-      end
-
+  
+  StockQuote::Stock::TYPES.each do |key|
+    describe key, vcr: { cassette_name: key} do
+      let(:range){
+        ['dividends', 'splits'].include?(key) ? StockQuote::Stock::RANGES.shuffle.shift : nil
+      }
       it "should be instance of Stock" do
-        expect(@stock).to be_an_instance_of(StockQuote::Stock)
+        @stock = StockQuote::Stock.send(key, 'aapl', range)
+        expectation(@stock)
       end
 
-      it "should respond to response_code" do
-        expect(@stock).to respond_to(:response_code)
-      end
-
-      (StockQuote::Stock::FIELDS - %w(f_annlyal_date fwpe eo events)).each do |k|
-        it "should respond to #{k}" do
-          expect(@stock).to respond_to(k)
-          expect(@stock.send(k)).to_not be_nil
-          expect(@stock.send(k).length).to be > 0
-        end
-      end
-    end
-    describe 'search results', vcr: { cassette_name: 'z'} do
-      it "should return array of suggestions is symbol isn't recognized" do
-        stocks = StockQuote::Stock.quote('Z')
-        expect(stocks.is_a?(Array)).to be(true)
-        expect(stocks.first).to be_an_instance_of(StockQuote::Stock)
-      end
-    end
-    describe 'comma seperated symbols', vcr: { cassette_name: 'aapl,tsla'} do
-      it 'should result in a successful query' do
-        @stocks = StockQuote::Stock.quote('aapl,tsla')
-        expect(@stocks.is_a?(Array)).to be(true)
-        expect(@stocks.first).to be_an_instance_of(StockQuote::Stock)
+      it "should be raw json hash" do
+        @stock = StockQuote::Stock.send("raw_#{key}", 'aapl', range)
+        expectation(@stock, 'json')
       end
     end
   end
-  describe 'history', vcr: { cassette_name: "aapl-history"} do
 
-    it 'should respond_to response_code' do
-      stock = StockQuote::Stock.quote('aapl', '01-Jan-2016')
+  describe '#query' do
+    describe 'single action' do
+      describe 'single symbol string', vcr: { cassette_name: "aapl"} do
+
+        it "should be instance of Stock" do
+          @stock = StockQuote::Stock.batch('quote','aapl')
+          expectation(@stock)
+        end
+
+        it "should be json" do
+          @stock = StockQuote::Stock.batch('quote','aapl',nil, 'json')
+          expectation(@stock, 'json')
+        end
+      end
+
+      describe 'multiple symbol array', vcr: { cassette_name: "aapl,tsla"} do
+
+        it "should be instance of Stock" do
+          @stock = StockQuote::Stock.batch('quote',['aapl', 'tsla'])
+          expectation(@stock)
+        end
+
+        it "should be json" do
+          @stock = StockQuote::Stock.batch('quote',['aapl', 'tsla'], nil, 'json')
+          expectation(@stock, 'json')
+        end
+      end
+
+      describe 'multiple symbol string', vcr: { cassette_name: "aapl,tsla"} do
+
+        it "should be instance of Stock" do
+          @stock = StockQuote::Stock.batch('quote','aapl,tsla')
+          expectation(@stock)
+        end
+
+        it "should be instance of Stock" do
+          @stock = StockQuote::Stock.batch('quote','aapl,tsla', nil, 'json')
+          expectation(@stock, 'json')
+        end
+      end
+    end
+    describe 'multiple action' do
+      describe 'multiple symbol array', vcr: { cassette_name: "aapl,tsla"} do
+
+        it "should be instance of Stock" do
+          @stock = StockQuote::Stock.batch(['quote','chart'],['aapl', 'tsla'])
+          expectation(@stock)
+        end
+
+        it "should be json" do
+          @stock = StockQuote::Stock.batch(['quote','chart'],['aapl', 'tsla'], nil, 'json')
+          expectation(@stock, 'json')
+        end
+      end
+
+      describe 'multiple symbol string', vcr: { cassette_name: "aapl,tsla"} do
+
+        it "should be instance of Stock" do
+          @stock = StockQuote::Stock.batch('quote,chart','aapl,tsla')
+          expectation(@stock)
+        end
+
+        it "should be instance of Stock" do
+          @stock = StockQuote::Stock.batch('quote,chart','aapl,tsla', nil, 'json')
+          expectation(@stock, 'json')
+        end
+      end
+    end
+  end
+
+  protected
+  
+  def expectation(stock, fmt=nil)
+    if stock.is_a?(Array)
+      stock.each{|s| expectation(s, fmt) }
+    elsif fmt=='json'
+      expect(stock).to be_an_instance_of(Hash)
+    else
+      expect(stock).to be_an_instance_of(StockQuote::Stock)
+      expect(stock).to respond_to(:symbol)
       expect(stock).to respond_to(:response_code)
-    end
-
-    it 'should return json' do
-      stock = StockQuote::Stock.quote('aapl', '01-Jan-2016', nil, 'json')
-      expect(stock.is_a?(Hash)).to be(true)
-    end
-
-    it 'should return multiple quotes' do
-      stock = StockQuote::Stock.quote('aapl,tsla', '01-Jan-2016')
-      expect(stock.first).to respond_to(:response_code)
-    end
-
-    it 'should raise runtime error for invalid query' do
-      expect{ StockQuote::Stock.quote('TE.V', '01-Jan-2016') }.to raise_error(RuntimeError)
-    end
-
-    describe 'versions of date allowed' do
-
-      it '01-Jan-2016' do
-        @stock = StockQuote::Stock.quote('aapl', '01-Jan-2016')
-        expect(@stock.history.last[:date]).to eq('4-Jan-16')
-      end
-
-      it '01-January-2016' do
-        @stock = StockQuote::Stock.quote('aapl', '01-January-2016')
-        expect(@stock.history.last[:date]).to eq('4-Jan-16')
-      end
-
-      it 'January 01, 2016' do
-        @stock = StockQuote::Stock.quote('aapl', 'January 01, 2016')
-        expect(@stock.history.last[:date]).to eq('4-Jan-16')
-      end
-
-      it '01/01/2016' do
-        @stock = StockQuote::Stock.quote('aapl', '01/01/2016')
-        expect(@stock.history.last[:date]).to eq('4-Jan-16')
-      end
-
-      it '01-01-2016' do
-        @stock = StockQuote::Stock.quote('aapl', '01-01-2016')
-        expect(@stock.history.last[:date]).to eq('4-Jan-16')
-      end
-
-      it '01-01-16' do
-        @stock = StockQuote::Stock.quote('aapl', '01-01-16')
-        expect(@stock.history.last[:date]).to eq('4-Jan-16')
-      end
-    end
-
-    describe 'static method' do
-      it 'should return quote' do
-        stock = StockQuote::Stock.json_quote('aapl')
-        expect(stock.is_a?(Hash)).to be(true)
-      end
-
-      it 'should return history' do
-        history = StockQuote::Stock.history('aapl', '01-Jan-2016', '01-Jan-2017')
-        expect(history.is_a?(Hash)).to be(true)
-      end
-
-      it 'should return json history' do
-        history = StockQuote::Stock.json_history('aapl', '01-Jan-2016', '01-Jan-2017')
-        expect(history.is_a?(Hash)).to be(true)
-      end
+      expect(stock).to respond_to(:attribution)
+      expect(stock.attribution).to be(StockQuote::Stock::ATTRIBUTION)
     end
   end
 end

--- a/stock_quote.gemspec
+++ b/stock_quote.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.authors     = ['Ty Rauber']
   s.email       = ['tyrauber@mac.com']
   s.homepage    = 'https://github.com/tyrauber/stock_quote'
-  s.summary     = 'A ruby gem that retrieves real-time stock quotes from google.'
-  s.description = 'Retrieve up to 100 stock quotes per query with the following variables - symbol, pretty_symbol, symbol_lookup_url, company, exchange, exchange_timezone, exchange_utc_offset, exchange_closing, divisor, currency, last, high, low, volume, avg_volume, market_cap, open, y_close, change, perc_change, delay, trade_timestamp, trade_date_utc, trade_time_utc, current_date_utc, current_time_utc, symbol_url, chart_url, disclaimer_url, ecn_url, isld_last, isld_trade_date_utc, isld_trade_time_utc, brut_last, brut_trade_date_utc, brut_trade_time_utc and daylight_savings - per stock.'
+  s.summary     = 'A ruby gem that retrieves real-time stock quotes from IEX.'
+  s.description = 'Retrieve book, chart, company, delayed quote, dividends, earnings, effective spread, financials, threshold securities, short interest, stats, lists, logo, news, OHLC, open/close, peers, previous, price, quote, relevant, splits, timeseries, volume by venue and batch requests through IEX (iextrading.com/developer)'
   s.rubyforge_project = 'stock_quote'
   s.license = 'MIT'
 

--- a/stock_quote.gemspec
+++ b/stock_quote.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.email       = ['tyrauber@mac.com']
   s.homepage    = 'https://github.com/tyrauber/stock_quote'
   s.summary     = 'A ruby gem that retrieves real-time stock quotes from IEX.'
-  s.description = 'Retrieve book, chart, company, delayed quote, dividends, earnings, effective spread, financials, threshold securities, short interest, stats, lists, logo, news, OHLC, open/close, peers, previous, price, quote, relevant, splits, timeseries, volume by venue and batch requests through IEX (iextrading.com/developer)'
+  s.description = 'Retrieve book, chart, company, delayed quote, dividends, earnings, effective spread, financials, stats, lists, logo, news, OHLC, open/close, peers, previous, price, quote, relevant, splits, timeseries, volume by venue and batch requests through IEX (iextrading.com/developer)'
   s.rubyforge_project = 'stock_quote'
   s.license = 'MIT'
 


### PR DESCRIPTION
Unfortunately, on or around March 15th, 2018, Google once again terminated public access to the Finance API.  Having rebuilt this gem more times than I'd like to admit - switching back and forth between Yahoo and Google with every API change and discontinuation - I seriously considered pulling stock_quote from rubygems and closing this repo.

Last night I found the [IEX Trading AP](https://iextrading.com/developer), a free, open, high-performance, comprehensive, well-documented finance API. I played around with the API a bit and was pretty impressed. It's functionally an improvement over previous versions that utilized Yahoo and Google Finance APIs.

I am a little hesitant about switching to IEX, an unknown newcomer, given how little stability Yahoo or Google provided -  and I HATE breaking changes - but the stock_quote is currently broken.

This branch updates stock_quote to use the IEX trading API.  It's free. No registration or API key is required.

To test out this branch, using the following syntax in your Gemfile:

```gem "stock_quote", github: 'tyrauber/stock_quote', branch: 'iex'```

The following query syntax still applies:

```StockQuote::Stock.query('aapl')```

With a whole host of additional [functionality](https://github.com/tyrauber/stock_quote/tree/iex).

I'd like to propose we merge this in as V2.0.0 of stock_quote.  Thoughts?